### PR TITLE
Use phusion/passenger-ruby33 (WIP)

### DIFF
--- a/Dockerfile.rurema-search
+++ b/Dockerfile.rurema-search
@@ -1,19 +1,27 @@
-FROM ruby:3.3.4
+FROM phusion/passenger-ruby33:3.0.6
 
 ENV DEBIAN_FRONTEND=noninteractive
 # groonga-suggest-create-dataset がなくて止まるので apt install groonga しておく
 RUN apt-get update -qy && apt-get install groonga libgroonga-dev -qy
 
 RUN adduser --uid 1001 rurema
+# Fix Error opening '/home/rurema/rurema-search/Passengerfile.json' for reading: Permission denied (errno=13); This error means that the Nginx worker process (PID 53, running as UID 33) does not have permission to access this file. Please read this page to learn how to fix this problem: https://www.phusionpassenger.com/library/admin/nginx/troubleshooting/?a=upon-accessing-the-web-app-nginx-reports-a-permission-denied-error
+RUN chmod 755 /home/rurema
 WORKDIR /home/rurema
 USER rurema
 
 COPY --chown=rurema:rurema repos/rurema-search rurema-search
 
 WORKDIR /home/rurema/rurema-search
+RUN bundle config set path vendor/bundle
 RUN bundle install
 RUN bundle add net-smtp
-RUN bundle add puma
 COPY --chown=rurema:rurema example/rurema-search/document.yaml document.yaml
 COPY --chown=rurema:rurema example/rurema-search/production.yaml production.yaml
 RUN install -m 755 -o rurema -g rurema -d groonga-database var/lib/suggest
+
+# passenger
+USER root
+RUN rm /etc/nginx/sites-enabled/default
+COPY example/nginx/default.conf /etc/nginx/sites-enabled/rurema.conf
+RUN rm -f /etc/service/nginx/down

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,18 +19,10 @@ services:
       - "./tool:/home/rurema/tool:ro"
       - "groonga-database:/home/rurema/rurema-search/groonga-database"
       - "suggest:/home/rurema/rurema-search/var/lib/suggest"
-    command: "bundle exec rackup --server puma --host 0.0.0.0"
-    ports:
-      - "9292:9292"
-
-  web:
-    image: nginx
-    volumes:
       - "./repos/docs.ruby-lang.org/public:/usr/share/nginx/html:ro"
       - "./html/ja:/usr/share/nginx/html/ja:ro"
       - "./example/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro"
     ports:
-      # Related: base_url in example/rurema-search/document.yaml
       - "9000:80"
 
 volumes:

--- a/example/nginx/default.conf
+++ b/example/nginx/default.conf
@@ -7,7 +7,15 @@ server {
         index  index.html;
     }
 
-    location /ja/search/ {
-        proxy_pass http://rurema-search:9292;
+    location ~ ^/ja/search(/.*|$) {
+        alias /home/rurema/rurema-search/public$1;
+        passenger_base_uri /ja/search;
+        passenger_app_root /home/rurema/rurema-search;
+        passenger_document_root /home/rurema/rurema-search/public;
+        passenger_enabled on;
+        passenger_user rurema;
+        passenger_group rurema;
+        #passenger_ruby /usr/bin/ruby3.3;
+        #passenger_ruby /usr/local/rvm/rubies/ruby-3.3.3/bin/ruby;
     }
 }

--- a/example/rurema-search/document.yaml
+++ b/example/rurema-search/document.yaml
@@ -1,5 +1,5 @@
 base_url:
-  http://localhost:9000/ja/
+  /ja/
 remove_dot_from_version:
   false
 tracking_id:


### PR DESCRIPTION
`base_url` 問題の対策案として、nginx で proxy_pass を使わずに直接 passenger でいけないか試しているのですが、未だに `/ja/search/` が開けるところまでいっていません。

`Passengerfile.json` のエラーは `/home/rurema` のパーミッションが 750 だったのを 755 にすれば直りました。

しかし、今は error.log をみると `strscan` などの default gem が `Gemfile.lock` とのバージョン違いでひっかかっているようです。
https://www.phusionpassenger.com/docs/advanced_guides/in_depth/ruby/bundler.html をみると自動で `bundle exec` 相当のことをしてくれるはずなので、なぜうまくいかないのかがわかっていません。

他の解決策を採用して、この方法は捨てるかもしれませんが、現状を draft pull request にしておきます。