### PR TITLE
manual/ (Markdown) ツリーから DB と HTML を生成する

### DIFF
--- a/tool/bc-setup-all.rb
+++ b/tool/bc-setup-all.rb
@@ -8,8 +8,8 @@ def setup_db(version)
     db = "#{DB_BASE}/db-#{version}"
     FileUtils.rm_rf db
     system(*%W"bundle exec bitclust -d #{db} init version=#{version} encoding=utf-8")
-    system(*%W"bundle exec bitclust -d #{db} update --stdlibtree=#{REF_BASE}/api/src")
-    system(*%W"bundle exec bitclust -d #{db} --capi update" + Dir.glob("#{REF_BASE}/capi/src/*"))
+    system(*%W"bundle exec bitclust -d #{db} update --markdowntree=#{MANUAL_BASE}/api")
+    system(*%W"bundle exec bitclust -d #{db} --capi update --markdowntree=#{MANUAL_BASE}/capi")
     puts "#{version} is done."
   end
 end

--- a/tool/update-rurema-index.rb
+++ b/tool/update-rurema-index.rb
@@ -1,4 +1,19 @@
 #!/usr/bin/env ruby
 
+# 暫定ガード: Markdown ソースの DB（properties に source_format=markdown）は
+# 現行の bitclust-indexer が解釈できない（メソッドが索引されず、既存レコードも
+# purge_old_records で消える）ため、索引の更新をスキップして既存 index を
+# 凍結する。恒久対応はクライアントサイド静的検索への移行。
+databases = Dir.glob(File.expand_path("../db/db-*", __dir__)).sort
+markdown_databases = databases.select do |db|
+  properties = File.join(db, "properties")
+  File.exist?(properties) && File.read(properties).match?(/^source_format=markdown$/)
+end
+unless markdown_databases.empty?
+  warn "skip indexing: bitclust-indexer does not support markdown-format databases:"
+  markdown_databases.each { |db| warn "  #{db}" }
+  exit
+end
+
 Dir.chdir(File.expand_path("../rurema-search", __dir__))
-Process.exec("bundle", "exec", "bin/bitclust-indexer", *Dir.glob("../db/db-*"))
+Process.exec("bundle", "exec", "bin/bitclust-indexer", *databases)

--- a/tool/vars.rb
+++ b/tool/vars.rb
@@ -11,7 +11,7 @@ VERSIONS = %w[
 DB_BASE = File.expand_path("../db", __dir__)
 
 DOC_BASE = File.expand_path("../doctree", __dir__)
-REF_BASE = "refm" # was "#{DOC_BASE}/refm"
+MANUAL_BASE = "manual" # was REF_BASE = "refm"
 
 TMP_HTML_BASE = File.expand_path("../tmp/html", __dir__)
 


### PR DESCRIPTION
## 概要

doctree の Markdown 移行（rurema/bitclust#189, rurema/doctree#3035）に伴い、docs.ruby-lang.org 向けビルドのソースを `refm/`（RRD）から `manual/`（Markdown）へ切り替えます。`refm/` は移行ウィンドウ中の凍結ソースとして doctree に残ります。

## 変更内容

1. **tool/bc-setup-all.rb** — DB 構築を doctree の Rakefile 切り替えと同じコマンド形に変更
   - `update --stdlibtree=refm/api/src` → `update --markdowntree=manual/api`
   - `--capi update refm/capi/src/*` → `--capi update --markdowntree=manual/capi`
2. **tool/vars.rb** — `REF_BASE = "refm"` → `MANUAL_BASE = "manual"`
3. **tool/update-rurema-index.rb** — Markdown 形式 DB（properties に `source_format=markdown`）を検出したら索引更新をスキップする暫定ガード。現行の bitclust-indexer は自前の `/\A---/` チャンク分割で md ソースを解釈できず、実行するとメソッドが 1 件も索引されないまま `purge_old_records` で既存レコードが消えるため、既存 index を凍結して劣化を防ぎます。恒久対応はクライアントサイド静的検索（bitclust の statichtml が生成する `search_data.js`）への移行で別途進めます。

## マージ条件（順序厳守）

1. rurema/bitclust#189（bitclust の Markdown ネイティブ対応）
2. rurema/doctree#3035（manual/ ツリー追加 + Rakefile 切り替え。マージ前に Gemfile の一時ピン revert）
3. **本 PR** — 上記 2 つが master に入るまでマージしないでください。`generate.sh` は両リポジトリの master を clone するため、先にマージすると `manual/` が無くビルドが失敗します。

## 影響範囲

- **db/db-\***: エントリの source が Markdown になり、properties に `source_format=markdown` が付きます。DB を読む側は md 対応の bitclust が必要です。
- **HTML**: MDCompiler（GFM モード）による描画。差分は GFM 強化（インラインコードスパン・テーブル）と既知残差 1 件（`JSON::State#generate` の meta 属性内改行）で、statichtml 13,535 ファイルの新旧比較と全 7 版の rake generate / statichtml（94,745 ファイル、UNKNOWN_META_INFO 0・compileerror 0）で検証済み（doctree#3035 の CI も 3 プラットフォーム全 green）。
- **編集リンク**: source_location が manual/ を指すため `https://github.com/rurema/doctree/edit/master/manual/api/_builtin/Array.md#L938` の形に自動で切り替わります。
- **rurema-search**: 上記ガードにより索引更新は当面凍結（既存 index で検索は動き続けます）。

## ローカル検証

- 変更後の `bc-setup-all.rb` を doctree `markdown/add-manual-tree` + bitclust `feature/markdown-conversion` に対して version 3.4 で実行 → DB 59MB、`source_format=markdown`、source_location が `manual/api/_builtin/Array.md:938` / `manual/capi/array.c.md:1` を指すことを確認。
- ガードは「md DB あり → skip・exit 0」「rd DB のみ → indexer 起動（引数はソート済み DB パス）」の両分岐と、実際に構築した md DB に対する発動を確認。

## ロールバック

本 PR の revert で旧経路（凍結 `refm/`）に戻せます。

マージ後、翌日の daily cron（generate.yml）で全版が再生成され auto-PR が出るので、その差分が上記「影響範囲」の想定内であることが受け入れ確認になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
