### PR TITLE
全バージョン対応の静的検索ページ (html/ja/search) を生成する

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -37,3 +37,4 @@ time docker compose run --rm rurema ls -al
 
 time docker compose run --rm rurema tool/bc-setup-all.rb
 time docker compose run --rm rurema tool/bc-static-all.rb
+time docker compose run --rm rurema tool/bc-search-page.rb

--- a/tool/bc-search-page.rb
+++ b/tool/bc-search-page.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+require 'fileutils'
+require_relative 'vars'
+
+# 全バージョン対応の静的検索ページ（docs.ruby-lang.org/ja/search/ の
+# rurema-search 置き換え）。全版の DB から versions タグ付きの統合 index と
+# ページ一式を html/ja/search/ に生成する。
+# bitclust の searchpage サブコマンドが必要（master マージ後に有効化する）。
+outputdir = "#{DOC_ROOT}/search"
+databases = VERSIONS.map { |version| "#{DB_BASE}/db-#{version}" }
+
+FileUtils.rm_rf outputdir
+system("bundle", "exec", "bitclust", "searchpage",
+       "--outputdir=#{outputdir}",
+       "--fs-casesensitive",
+       *databases,
+       chdir: DOC_BASE) or raise "Failed to generate search page"
+puts "search page is done."


### PR DESCRIPTION
## 概要

docs.ruby-lang.org/ja/search/（るりまサーチ）置き換えの生成側。`tool/bc-search-page.rb` を追加し、`bc-setup-all.rb` が構築した全版の DB から `bitclust searchpage` で全バージョン対応の静的検索ページを `html/ja/search/` に生成します（generate.sh の最後に実行）。

実測では 2 版で gzip 176KB（1 版とほぼ同じ、重複排除が効く）なので、7 版でも配信サイズは問題になりません。

## マージ条件

- rurema/bitclust の searchpage サブコマンド追加 PR が master に入っていること（generate.sh は bitclust master を clone するため、先にマージすると翌日のビルドが失敗します）

## 検証

実 DB（3.0 + 3.4）を使い、本スクリプトの実体を vars 差し替えハーネスで実行して `html/ja/search/`（index.html / js/search_data.js / vendored JS + NOTICE / search.css）の生成を確認済み。

## 後続

- ruby/docs.ruby-lang.org: `system/bc-static-all` の rsync 対象に search ディレクトリを追加（別 PR）
- インフラ: `/ja/search/` をアプリへのプロキシから静的配信へ切り替え。切り替え後、本リポジトリの rurema-search 関連（build.sh の該当節・compose の rurema-search サービス・Dockerfile.rurema-search・tool/update-rurema-index.rb・example/rurema-search/）は撤去可能になります

🤖 Generated with [Claude Code](https://claude.com/claude-code)
