### PR TITLE
Pass --eol-warning to statichtml for EOL versions

### DIFF
--- a/tool/static_html.rb
+++ b/tool/static_html.rb
@@ -26,6 +26,7 @@ def create_document(version, edit_base_url: "https://github.com/rurema/doctree/e
   ]
   command << "--edit-base-url=#{edit_base_url}" if edit_base_url
   command << "--no-stop-on-syntax-error" unless stop_on_syntax_error
+  command << "--eol-warning" if MINIMUM_SUPPORTED_RUBY_VERSION > version
   system(*command, chdir: DOC_BASE) or raise
   system("rsync", "-acvi", "--no-times", "--delete", outputdir, DOC_ROOT) or raise
   FileUtils.rm_rf outputdir

--- a/tool/vars.rb
+++ b/tool/vars.rb
@@ -33,6 +33,12 @@ VERSIONS = %w[
 
 ALL_VERSIONS = FROZEN_VERSIONS + VERSIONS
 
+# メンテナンスが継続している最古のバージョン。これより古い版の静的 HTML には
+# EOL 警告バナーを表示する（bitclust statichtml --eol-warning）。
+# EOL 状況は https://www.ruby-lang.org/ja/downloads/branches/
+# （一次データは ruby/www.ruby-lang.org の _data/branches.yml）を参照して更新する
+MINIMUM_SUPPORTED_RUBY_VERSION = Gem::Version.new("3.3")
+
 DB_BASE = File.expand_path("../db", __dir__)
 
 DOC_BASE = File.expand_path("../doctree", __dir__)


### PR DESCRIPTION
## 概要

rurema/bitclust の `statichtml --eol-warning`（bitclust 側 PR 参照）に対応し、
docs.ruby-lang.org の EOL バージョンのページに警告バナーを表示します。

- `tool/vars.rb`: `MINIMUM_SUPPORTED_RUBY_VERSION = Gem::Version.new("3.3")` を追加
  （3.2 は 2026-04-01 に EOL。一次データは ruby/www.ruby-lang.org の
  `_data/branches.yml`）
- `tool/static_html.rb` の `create_document`: `MINIMUM_SUPPORTED_RUBY_VERSION > version`
  の場合に `--eol-warning` を付与
- 対象: FROZEN_VERSIONS 全部（1.8.7〜2.7.0）と、毎日再生成する VERSIONS の
  うち 3.0〜3.2。3.3 以降は対象外

今後ブランチが EOL になったらこの定数を上げるだけです（bitclust の
リリースや変更は不要）。将来的には branches.yml から自動判定する案も
ありますが、別 Issue とします。

## 依存・マージ順

**bitclust 側 PR のマージが先**です（旧 bitclust に `--eol-warning` を
渡すと optparse エラーでビルドが失敗します）。

反映タイミング:
- 3.0〜3.2: マージ後最初の daily generate.sh で反映
- 凍結版（1.8.7〜2.7.0）: bitclust 側 PR のマージで `BITCLUST_CHANGED=1` になる
  ため、その日の generate.sh で `tool/bc-static-frozen.rb` が走って反映

## 検証

- `ruby -c` と、`tool/vars.rb` を require して条件を確認:
  1.8.7, 2.7.0, 3.0, 3.2 → 付与 / 3.3, 3.4, 4.0, 4.1 → 付与なし
- バナー本体の描画・全ページ反映は bitclust 側 PR で検証済み
  （実 DB で 12,000+ ページ生成し全ページにバナーが入ることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
