### PR TITLE
Pass --run-ruby-wasm to statichtml for versions with a ruby.wasm build

### DIFF
--- a/tool/static_html.rb
+++ b/tool/static_html.rb
@@ -2,6 +2,27 @@
 require 'fileutils'
 require_relative 'vars'
 
+# 未リリース版（VERSIONS 末尾 = /ja/master/ symlink の実体）には head 用
+# スナップショット (@ruby/head-wasm-wasi) を使う。ただしスナップショットの
+# 元になる ruby/ruby master のバージョンが version と一致するときだけ
+# （リリース移行期に master が次の開発版に進んでいる場合は自動で無効になる）。
+# URL はその日の next スナップショットに完全固定する。判定・取得に失敗しても
+# ビルドは止めず、RUN ボタンなしにフォールバックする。
+def ruby_head_wasm_url(version)
+  require 'net/http'
+  require 'json'
+  version_h = Net::HTTP.get(URI("https://raw.githubusercontent.com/ruby/ruby/master/include/ruby/version.h"))
+  major = version_h[/RUBY_API_VERSION_MAJOR (\d+)/, 1]
+  minor = version_h[/RUBY_API_VERSION_MINOR (\d+)/, 1]
+  return nil unless version == "#{major}.#{minor}"
+  tags = JSON.parse(Net::HTTP.get(URI("https://data.jsdelivr.com/v1/packages/npm/@ruby/head-wasm-wasi")))["tags"]
+  snapshot = tags["next"] or return nil
+  "https://cdn.jsdelivr.net/npm/@ruby/head-wasm-wasi@#{snapshot}/dist/ruby+stdlib.wasm"
+rescue StandardError => e
+  warn "ruby_head_wasm_url: #{e.class}: #{e.message} (disabling the RUN button for #{version})"
+  nil
+end
+
 # edit_base_url: nil を渡すと編集リンクを出さない（凍結版。
 # 対応するソースが doctree の master に存在しないため）
 # stop_on_syntax_error: false を渡すとサンプルコードの
@@ -27,6 +48,9 @@ def create_document(version, edit_base_url: "https://github.com/rurema/doctree/e
   command << "--edit-base-url=#{edit_base_url}" if edit_base_url
   command << "--no-stop-on-syntax-error" unless stop_on_syntax_error
   command << "--eol-warning" if MINIMUM_SUPPORTED_RUBY_VERSION > version
+  wasm_url = RUBY_WASM_URLS[version]
+  wasm_url ||= ruby_head_wasm_url(version) if version == VERSIONS[-1]
+  command << "--run-ruby-wasm=#{wasm_url}" if wasm_url
   system(*command, chdir: DOC_BASE) or raise
   system("rsync", "-acvi", "--no-times", "--delete", outputdir, DOC_ROOT) or raise
   FileUtils.rm_rf outputdir

--- a/tool/vars.rb
+++ b/tool/vars.rb
@@ -39,6 +39,16 @@ ALL_VERSIONS = FROZEN_VERSIONS + VERSIONS
 # （一次データは ruby/www.ruby-lang.org の _data/branches.yml）を参照して更新する
 MINIMUM_SUPPORTED_RUBY_VERSION = Gem::Version.new("3.3")
 
+# サンプルコードの RUN ボタン（bitclust statichtml --run-ruby-wasm）を有効に
+# するバージョン → 実行に使う ruby.wasm の URL。ruby.wasm 側に
+# @ruby/X.Y-wasm-wasi パッケージが存在するバージョンのみ列挙する
+# （https://github.com/ruby/ruby.wasm 参照）。凍結版・未リリース版は含めない
+# npm 上の安定版は「<パッケージ版>-<ruby.wasm版>」形式（latest dist-tag の値）
+RUBY_WASM_NPM_VERSION = "2.9.3-2.9.4"
+RUBY_WASM_URLS = %w[3.2 3.3 3.4 4.0].to_h { |v|
+  [v, "https://cdn.jsdelivr.net/npm/@ruby/#{v}-wasm-wasi@#{RUBY_WASM_NPM_VERSION}/dist/ruby+stdlib.wasm"]
+}
+
 DB_BASE = File.expand_path("../db", __dir__)
 
 DOC_BASE = File.expand_path("../doctree", __dir__)


### PR DESCRIPTION
## 概要

rurema/bitclust の `statichtml --run-ruby-wasm`（bitclust 側 PR 参照）に対応し、
docs.ruby-lang.org のうち ruby.wasm ビルドが存在するバージョン（3.2〜4.0）の
ページでサンプルコードの RUN ボタンを有効にします。

- `tool/vars.rb`: `RUBY_WASM_NPM_VERSION = "2.9.3-2.9.4"` と `RUBY_WASM_URLS`
  （3.2/3.3/3.4/4.0 → 版一致の jsdelivr URL の Hash）を追加
- `tool/static_html.rb` の `create_document`: map にある版は
  `--run-ruby-wasm=<URL>` を付与
- **未リリース版（`VERSIONS[-1]` = /ja/master/ symlink の実体、現在 4.1）は
  head 用スナップショット `@ruby/head-wasm-wasi` を使用**。ただしビルド時に
  ruby/ruby master の version.h と突き合わせ、スナップショットが本当に
  その版に対応しているときだけ有効化（リリース移行期は自動で無効）。
  URL は daily ビルドごとにその日の `next` スナップショットへ完全固定。
  判定・取得の失敗（ネットワーク等）はビルドを止めず RUN ボタンなしに
  フォールバック
- 凍結版（1.8.7〜2.7.0）と 3.0/3.1 は従来どおり
  （`bc-static-frozen.rb` の変更も不要）

## 依存・マージ順

**bitclust 側 PR のマージが先**です（旧 bitclust に `--run-ruby-wasm` を
渡すと optparse エラーでビルドが失敗します）。本番の daily generate.sh は
`repos/bitclust` を毎回 origin/master に更新してから doctree の bundle を
`BITCLUST_PATH=../bitclust`（path source）で解決するので、bitclust マージ後で
あれば lockfile 等の追加対応は不要です。

反映タイミング: マージ後最初の daily generate.sh で 3.2〜4.0 の再生成時に反映。

## ruby.wasm のバージョン更新について

`RUBY_WASM_NPM_VERSION` は完全固定（@latest 不使用、サプライチェーン対策）
なので、ruby.wasm の新リリース追従はこの定数の更新で行います。新しい Ruby
（4.1 リリース時等）は `RUBY_WASM_URLS` への追加で有効化できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
