### PR TITLE
statichtml の tracking-id を GA4 の測定 ID に更新

### DIFF
--- a/tool/static_html.rb
+++ b/tool/static_html.rb
@@ -42,7 +42,7 @@ def create_document(version, edit_base_url: "https://github.com/rurema/doctree/e
     "--fs-casesensitive",
     "--canonical-base-url=https://docs.ruby-lang.org/ja/latest/",
     "--meta-robots-content=",
-    "--tracking-id=UA-620926-3",
+    "--tracking-id=G-HBG2MP4NRL",
     "--quiet",
   ]
   command << "--edit-base-url=#{edit_base_url}" if edit_base_url


### PR DESCRIPTION
## 概要

`tool/static_html.rb` が bitclust statichtml に渡す `--tracking-id` を
UA-620926-3 → **G-HBG2MP4NRL** に置き換えます。

旧 ID は Universal Analytics のプロパティで、UA の計測停止（2023-07）以降、
/ja/ の全生成ページの gtag スニペットは何も収集していませんでした。
bitclust が出力するスニペットは GA4 と同じ形式のため ID の置換のみでよく、
マージ後の daily build で全バージョンのページに反映されます。

トップページ等の静的 index.html と、GA 使用を明示するプライバシー
ポリシーページの追加は ruby/docs.ruby-lang.org 側の対応 PR で行います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
