### PR TITLE
EOL バナーの閾値を branches.yml から自動更新するワークフローを追加

### DIFF
--- a/.github/workflows/update_eol.yml
+++ b/.github/workflows/update_eol.yml
@@ -1,0 +1,55 @@
+name: update EOL threshold
+
+# EOL 警告バナーの閾値(tool/vars.rb の MINIMUM_SUPPORTED_RUBY_VERSION)を
+# ruby/www.ruby-lang.org の _data/branches.yml から自動更新する。#144 参照。
+#
+# Ruby の EOL は 3月末〜4月に集中する(過去実績: 3/26, 3/31, 4/1, 4/12, 4/23)
+# ため、3〜4月は毎日、それ以外は週1(月曜)で確認する。
+# 実行時刻は generate (17:05 UTC) の 30 分前。閾値の更新が auto-merge されれば
+# 同日の generate で EOL バナーに反映される。
+
+on:
+  schedule:
+    - cron: '35 16 * 3,4 *'
+    - cron: '35 16 * 1,2,5-12 1'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  update-eol:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Update MINIMUM_SUPPORTED_RUBY_VERSION from branches.yml
+        id: update
+        run: ruby tool/update-eol.rb
+      - name: Create Pull Request
+        id: cpr
+        if: ${{ steps.update.outputs.changed == 'true' }}
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: update-eol-threshold
+          delete-branch: true
+          add-paths: |
+            tool/vars.rb
+          title: 'EOL バナーの閾値を ${{ steps.update.outputs.new_version }} に更新'
+          body: >
+            ruby/www.ruby-lang.org の _data/branches.yml の status 判定により、
+            EOL 警告バナーの閾値 MINIMUM_SUPPORTED_RUBY_VERSION を
+            ${{ steps.update.outputs.old_version }} から
+            ${{ steps.update.outputs.new_version }} に更新します(#144)。
+            automerge=${{ steps.update.outputs.automerge }}
+            (false の場合は2段階以上の引き上げのため人間による確認が必要です)。
+            This PR is auto-generated.
+      - name: Enable auto-merge
+        if: ${{ steps.cpr.outputs.pull-request-number && steps.update.outputs.automerge == 'true' }}
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+          gh pr merge --auto --delete-branch --merge "$PR_URL"
+        env:
+          PR_URL: "${{ steps.cpr.outputs.pull-request-url }}"
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/tool/update-eol.rb
+++ b/tool/update-eol.rb
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# ruby/www.ruby-lang.org の _data/branches.yml から各ブランチのメンテナンス
+# 状況を取得し、EOL 警告バナーの閾値 MINIMUM_SUPPORTED_RUBY_VERSION
+# (tool/vars.rb)を更新する。#144 参照。
+#
+# 判定: status が "eol" でないブランチのうち最小のバージョンを閾値とする。
+#
+# 挙動:
+# - 変更不要(導出値 == 現行値)なら何もしない(changed=false)
+# - 1段階の引き上げなら vars.rb を書き換え、automerge=true を出力
+# - 2段階以上の引き上げも書き換えるが automerge=false
+#   (ワークフロー側で auto-merge せず、人間レビュー用の PR として残す)
+# - 引き下げ・VERSIONS に無い値・取得/パース失敗は何も書き換えずエラー終了
+#
+# 出力は GITHUB_OUTPUT(あれば)と標準出力の両方に書く。
+# テスト用に ARGV[0] でローカルの branches.yml ファイルを指定できる。
+
+require "net/http"
+require "yaml"
+require "date"
+require_relative "vars"
+
+BRANCHES_YML_URL = "https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/branches.yml"
+
+def emit(key, value)
+  if (path = ENV["GITHUB_OUTPUT"])
+    File.open(path, "a") { |f| f.puts "#{key}=#{value}" }
+  end
+  puts "#{key}=#{value}"
+end
+
+if ARGV[0]
+  body = File.read(ARGV[0])
+else
+  res = Net::HTTP.get_response(URI(BRANCHES_YML_URL))
+  abort "branches.yml の取得に失敗: #{res.code} #{BRANCHES_YML_URL}" unless res.is_a?(Net::HTTPSuccess)
+  body = res.body
+end
+
+branches = YAML.safe_load(body, permitted_classes: [Date])
+abort "branches.yml の構造が想定外です" unless branches.is_a?(Array) && branches.all? { |b| b.is_a?(Hash) && b["name"] }
+
+supported = branches.reject { |b| b["status"].to_s == "eol" }.map { |b| b["name"].to_s }
+abort "サポート中のブランチが見つかりません(全 eol は想定外)" if supported.empty?
+
+derived = supported.min_by { |v| Gem::Version.new(v) }
+current = MINIMUM_SUPPORTED_RUBY_VERSION
+derived_v = Gem::Version.new(derived)
+
+emit("derived", derived)
+
+if derived_v == current
+  puts "MINIMUM_SUPPORTED_RUBY_VERSION は #{current} のままで正しい(変更なし)"
+  emit("changed", "false")
+  exit 0
+end
+
+if derived_v < current
+  abort "導出値 #{derived} が現行値 #{current} より古い。branches.yml が異常な可能性があるため書き換えない"
+end
+
+unless VERSIONS.include?(derived)
+  abort "導出値 #{derived} が VERSIONS に存在しない。vars.rb の VERSIONS 更新(リリース対応)が先"
+end
+
+cur_idx = VERSIONS.index(current.to_s)
+steps = cur_idx ? VERSIONS.index(derived) - cur_idx : 999
+
+vars_path = File.expand_path("vars.rb", __dir__)
+src = File.read(vars_path)
+pattern = /^MINIMUM_SUPPORTED_RUBY_VERSION = Gem::Version\.new\("#{Regexp.escape(current.to_s)}"\)$/
+abort "vars.rb に MINIMUM_SUPPORTED_RUBY_VERSION の行が見つからない" unless src.match?(pattern)
+File.write(vars_path, src.sub(pattern, %Q(MINIMUM_SUPPORTED_RUBY_VERSION = Gem::Version.new("#{derived}"))))
+
+emit("changed", "true")
+emit("old_version", current.to_s)
+emit("new_version", derived)
+emit("automerge", (steps == 1).to_s)
+if steps == 1
+  puts "#{current} -> #{derived} に更新(1段階なので auto-merge 可)"
+else
+  puts "#{current} -> #{derived} に更新(#{steps}段階の引き上げのため要人間レビュー。auto-merge しない)"
+end


### PR DESCRIPTION
Fixes #144

EOL 警告バナーの閾値(`tool/vars.rb` の `MINIMUM_SUPPORTED_RUBY_VERSION`)を、ruby/www.ruby-lang.org の `_data/branches.yml` から自動更新するワークフローを追加します。ビルド時の動的判定(issue 記載の原案)ではなく「別ワークフローが定数を書き換えて PR+auto-merge」方式にしたので、daily の generate に外部取得の依存は増えず、取得に失敗しても現行値でビルドが回り続けます。

## 仕組み

- **判定**: `status` が `eol` でないブランチの最小バージョンを閾値とする(現データでは 3.2=eol / 3.3=security maintenance なので導出値は 3.3 =現行値。**導入直後は no-op**)
- **スケジュール**: EOL が3月末〜4月に集中する実績(3/26・3/31・4/1・4/12・4/23)に合わせ、**3〜4月は毎日・それ以外は週1(月曜)**。時刻は generate(17:05 UTC)の30分前の 16:35 UTC で、auto-merge が間に合えば同日の generate でバナーに反映。`workflow_dispatch` でも起動可
- **更新**: 変更があるときだけ `tool/update-eol.rb` が vars.rb の該当行を書き換え、`peter-evans/create-pull-request` で PR 作成 → `gh pr merge --auto`(generate.yml と同じパターン)
- **ガード**:
  - 1段階の引き上げのみ auto-merge。2段階以上の引き上げは PR を作るが auto-merge せず人間レビューに残す(本文に automerge=false と明記)
  - 引き下げ(branches.yml 異常の疑い)・`VERSIONS` に無い値・取得/パース失敗は何も書き換えずジョブを失敗させる
- **スコープ**: 閾値のみ。`VERSIONS`→`FROZEN_VERSIONS` の移動(凍結)は doctree の frozen タグ・DB Import 等の人手作業とセットのため対象外

## 検証

`tool/update-eol.rb` はテスト用にローカルの branches.yml を引数で渡せます。実データ(2026-07-12 時点)で以下を確認済み:

- 現行値 3.3: `changed=false`、vars.rb 不変(no-op)
- 現行値 3.2(1段階): 3.3 に書き換え、`automerge=true`、GITHUB_OUTPUT 出力正常
- 現行値 3.0(3段階): 3.3 に書き換え、`automerge=false`
- 現行値 3.4(引き下げ): 書き換えず exit 1
- workflow YAML は `YAML.load_file` でパース確認
